### PR TITLE
Validate parentCapabilities.

### DIFF
--- a/ProfileManager.js
+++ b/ProfileManager.js
@@ -632,9 +632,9 @@ export default class ProfileManager {
     profileAgentId,
     referenceIdPrefix
   }) {
-    assert.parentCapabilitiesValidator(
+    assert.parentCapabilitiesValidator({
       parentCapabilities, edvId, hmac, keyAgreementKey
-    );
+    });
     const delegateEdvDocumentsRequest = {
       referenceId: `${referenceIdPrefix}-edv-documents`,
       allowedAction: ['read', 'write'],

--- a/ProfileManager.js
+++ b/ProfileManager.js
@@ -632,11 +632,9 @@ export default class ProfileManager {
     profileAgentId,
     referenceIdPrefix
   }) {
-    // TODO: validate `parentCapabilities`
-    // if no `edvId` then `parentCapabilities.edv` required
-    // if no `hmac` then `parentCapabilities.hmac` required
-    // if no `keyAgreement` then `parentCapabilities.keyAgreementKey` required
-
+    assert.parentCapabilitiesValidator(
+      parentCapabilities, edvId, hmac, keyAgreementKey
+    );
     const delegateEdvDocumentsRequest = {
       referenceId: `${referenceIdPrefix}-edv-documents`,
       allowedAction: ['read', 'write'],

--- a/assert.js
+++ b/assert.js
@@ -12,4 +12,32 @@ export function nonEmptyString(value, key) {
     throw new TypeError(`"${key}" must be a non-empty string.`);
   }
 }
-export default {nonEmptyString};
+/**
+  * Ensures `parentCapabilities` has all required properties.
+  *
+  * @param {object} parentCapabilities - Contains the properties edvId and
+  *   edvRevocations.
+  * @param {string} edvId - The ID of the EDV that must be a URL
+  *   that refers to the EDV's root storage location.
+  * @param {object} hmac - A default HMAC API for blinding indexable
+  *   attributes.
+  * @param {object} keyAgreementKey - A default KeyAgreementKey API for
+  *   deriving shared KEKs for wrapping content encryption keys.
+  *
+  * @throws - If the value is undefined.
+  * @returns {undefined} - It just throws or you are ok.
+  */
+export function parentCapabilitiesValidator(
+  parentCapabilities, edvId, hmac, keyAgreementKey
+) {
+  if(!edvId && !parentCapabilities.edv) {
+    throw new TypeError('"edvId" is required.');
+  }
+  if(!hmac && !parentCapabilities.hmac) {
+    throw new TypeError('"hmac" is required.');
+  }
+  if(!keyAgreementKey && !parentCapabilities.keyAgreementKey) {
+    throw new TypeError('"keyAgreementKey" is required.');
+  }
+}
+export default {nonEmptyString, parentCapabilitiesValidator};

--- a/assert.js
+++ b/assert.js
@@ -20,21 +20,16 @@ export function nonEmptyString(value, key) {
 /**
  * Ensures `parentCapabilities` has all required properties.
  *
- * @param {object} parentCapabilities - Contains the properties edvId and
- *    edvRevocations.
- * @param {string} edvId - The ID of the EDV that must be a URL
- *    that refers to the EDV's root storage location.
- * @param {object} hmac - A default HMAC API for blinding indexable
- *    attributes.
- * @param {object} keyAgreementKey - A default KeyAgreementKey API for
- *    deriving shared KEKs for wrapping content encryption keys.
- * @param {string} parentCapabilities.edvId -  - The ID of the EDV that must be
- *    a URL that refers to the EDV's root storage location.
- * @param {object} parentCapabilities.hmac - A default HMAC API for blinding
- *    indexable attributes.
- * @param {object} parentCapabilities.keyAgreementKey - A default
- *    KeyAgreementKey API for deriving shared KEKs for wrapping content
- *    encryption keys.
+ * @param {object} options - The options to use.
+ * @param {object} options.parentCapabilities - Contains the properties edvId
+ *   and edvRevocations.
+ * @param {string} options.edvId - The ID of the EDV that must be
+ *   a URL that refers to the EDV's root storage location.
+ * @param {object} options.hmac - A default HMAC API for blinding
+ *   indexable attributes.
+ * @param {object} options.keyAgreementKey - A default
+ *   KeyAgreementKey API for deriving shared KEKs for wrapping content
+ *   encryption keys.
  *
  * @throws - If both of the required properties are undefined.
  * @returns {undefined} - No value is returned upon successful execution.

--- a/assert.js
+++ b/assert.js
@@ -5,7 +5,7 @@
   * @param {string} key - The identifier for the parameter.
   *
   * @throws - If the value is not a string or is empty.
-  * @returns {undefined} - It just throws or you are ok.
+  * @returns {undefined} - No value is returned upon successful execution.
 */
 export function nonEmptyString(value, key) {
   if(!(value && typeof value === 'string')) {
@@ -24,19 +24,19 @@ export function nonEmptyString(value, key) {
   * @param {object} keyAgreementKey - A default KeyAgreementKey API for
   *   deriving shared KEKs for wrapping content encryption keys.
   *
-  * @throws - If the value is undefined.
-  * @returns {undefined} - It just throws or you are ok.
+  * @throws - If both of the required properties are undefined.
+  * @returns {undefined} - No value is returned upon successful execution.
   */
 export function parentCapabilitiesValidator(
   parentCapabilities, edvId, hmac, keyAgreementKey
 ) {
-  if(!edvId && !parentCapabilities.edv) {
+  if(!(edvId || parentCapabilities.edv)) {
     throw new TypeError('"edvId" is required.');
   }
-  if(!hmac && !parentCapabilities.hmac) {
+  if(!(hmac || parentCapabilities.hmac)) {
     throw new TypeError('"hmac" is required.');
   }
-  if(!keyAgreementKey && !parentCapabilities.keyAgreementKey) {
+  if(!(keyAgreementKey || parentCapabilities.keyAgreementKey)) {
     throw new TypeError('"keyAgreementKey" is required.');
   }
 }

--- a/assert.js
+++ b/assert.js
@@ -1,3 +1,7 @@
+/*!
+ * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
+ */
+
 /**
   * Ensures an expected string is not empty.
   *
@@ -12,24 +16,32 @@ export function nonEmptyString(value, key) {
     throw new TypeError(`"${key}" must be a non-empty string.`);
   }
 }
+
 /**
-  * Ensures `parentCapabilities` has all required properties.
-  *
-  * @param {object} parentCapabilities - Contains the properties edvId and
-  *   edvRevocations.
-  * @param {string} edvId - The ID of the EDV that must be a URL
-  *   that refers to the EDV's root storage location.
-  * @param {object} hmac - A default HMAC API for blinding indexable
-  *   attributes.
-  * @param {object} keyAgreementKey - A default KeyAgreementKey API for
-  *   deriving shared KEKs for wrapping content encryption keys.
-  *
-  * @throws - If both of the required properties are undefined.
-  * @returns {undefined} - No value is returned upon successful execution.
-  */
-export function parentCapabilitiesValidator(
+ * Ensures `parentCapabilities` has all required properties.
+ *
+ * @param {object} parentCapabilities - Contains the properties edvId and
+ *    edvRevocations.
+ * @param {string} edvId - The ID of the EDV that must be a URL
+ *    that refers to the EDV's root storage location.
+ * @param {object} hmac - A default HMAC API for blinding indexable
+ *    attributes.
+ * @param {object} keyAgreementKey - A default KeyAgreementKey API for
+ *    deriving shared KEKs for wrapping content encryption keys.
+ * @param {string} parentCapabilities.edvId -  - The ID of the EDV that must be
+ *    a URL that refers to the EDV's root storage location.
+ * @param {object} parentCapabilities.hmac - A default HMAC API for blinding
+ *    indexable attributes.
+ * @param {object} parentCapabilities.keyAgreementKey - A default
+ *    KeyAgreementKey API for deriving shared KEKs for wrapping content
+ *    encryption keys.
+ *
+ * @throws - If both of the required properties are undefined.
+ * @returns {undefined} - No value is returned upon successful execution.
+ */
+export function parentCapabilitiesValidator({
   parentCapabilities, edvId, hmac, keyAgreementKey
-) {
+}) {
   if(!(edvId || parentCapabilities.edv)) {
     throw new TypeError('"edvId" is required.');
   }
@@ -40,4 +52,5 @@ export function parentCapabilitiesValidator(
     throw new TypeError('"keyAgreementKey" is required.');
   }
 }
+
 export default {nonEmptyString, parentCapabilitiesValidator};

--- a/test/web/10-api.js
+++ b/test/web/10-api.js
@@ -698,6 +698,91 @@ describe('Profile Manager API', () => {
       error.name.should.equal('TypeError');
       error.message.should.contain('profileId');
     });
+    it('should fail if no edvId', async () => {
+      const hmac = {
+        id: 'z19pHg1APVprWk1ALrcZUnXWL',
+        type: 'Sha256HmacKey2019'
+      };
+      const keyAgreementKey = {
+        id: 'z19xp4DANMn8k9Yy8m6ZCE6PV',
+        type: 'X25519KeyAgreementKey2019',
+      };
+      const parentCapabilities = {
+        hmac: {
+          id: 'z19pHg1APVprWk1ALrcZUnXWL',
+          type: 'Sha256HmacKey2019'
+        },
+        keyAgreementKey: {
+          id: 'z19xp4DANMn8k9Yy8m6ZCE6PV',
+          type: 'X25519KeyAgreementKey2019',
+        }
+      };
+      let error, result = null;
+      try {
+        result = await profileManager.delegateEdvCapabilities({
+          parentCapabilities, hmac, keyAgreementKey
+        });
+      } catch(e) {
+        error = e;
+      }
+      should.not.exist(result);
+      should.exist(error);
+      error.name.should.equal('TypeError');
+      error.message.should.contain('edvId');
+    });
+    it('should fail if no hmac', async () => {
+      const edvId = 'z19uMCiPNET4YbcPpBcab5mEE';
+      const keyAgreementKey = {
+        id: 'z19xp4DANMn8k9Yy8m6ZCE6PV',
+        type: 'X25519KeyAgreementKey2019',
+      };
+      const parentCapabilities = {
+        edvId: 'z19uMCiPNET4YbcPpBcab5mEE',
+        keyAgreementKey: {
+          id: 'z19xp4DANMn8k9Yy8m6ZCE6PV',
+          type: 'X25519KeyAgreementKey2019',
+        }
+      };
+      let error, result = null;
+      try {
+        result = await profileManager.delegateEdvCapabilities({
+          parentCapabilities, edvId, keyAgreementKey
+        });
+      } catch(e) {
+        error = e;
+      }
+      should.not.exist(result);
+      should.exist(error);
+      error.name.should.equal('TypeError');
+      error.message.should.contain('hmac');
+    });
+    it('should fail if no keyAgreementKey', async () => {
+      const edvId = 'z19uMCiPNET4YbcPpBcab5mEE';
+      const hmac = {
+        id: 'z19pHg1APVprWk1ALrcZUnXWL',
+        type: 'Sha256HmacKey2019'
+      };
+      const parentCapabilities = {
+        edvId: 'z19uMCiPNET4YbcPpBcab5mEE',
+        hmac: {
+          id: 'z19pHg1APVprWk1ALrcZUnXWL',
+          type: 'Sha256HmacKey2019'
+        },
+      };
+      let error, result = null;
+      try {
+        result = await profileManager.delegateEdvCapabilities({
+          parentCapabilities, edvId, hmac
+        });
+      } catch(e) {
+        error = e;
+      }
+      should.not.exist(result);
+      should.exist(error);
+      error.name.should.equal('TypeError');
+      error.message.should.contain('keyAgreementKey');
+    });
+
   });
   describe('getCollection api', () => {
     let profileManager;

--- a/test/web/10-api.js
+++ b/test/web/10-api.js
@@ -4,6 +4,7 @@
 'use strict';
 
 import {ProfileManager} from 'bedrock-web-profile-manager';
+import {mockData} from './mock.data.js';
 
 const ACCOUNT_ID = 'urn:uuid:ffaf5d84-7dc2-4f7b-9825-cc8d2e5a5d06';
 const KMS_MODULE = 'ssm-v1';
@@ -699,24 +700,8 @@ describe('Profile Manager API', () => {
       error.message.should.contain('profileId');
     });
     it('should fail if no edvId', async () => {
-      const hmac = {
-        id: 'z19pHg1APVprWk1ALrcZUnXWL',
-        type: 'Sha256HmacKey2019'
-      };
-      const keyAgreementKey = {
-        id: 'z19xp4DANMn8k9Yy8m6ZCE6PV',
-        type: 'X25519KeyAgreementKey2019',
-      };
-      const parentCapabilities = {
-        hmac: {
-          id: 'z19pHg1APVprWk1ALrcZUnXWL',
-          type: 'Sha256HmacKey2019'
-        },
-        keyAgreementKey: {
-          id: 'z19xp4DANMn8k9Yy8m6ZCE6PV',
-          type: 'X25519KeyAgreementKey2019',
-        }
-      };
+      const {parentCapabilities, hmac, keyAgreementKey} = mockData;
+      delete parentCapabilities.edv;
       let error, result = null;
       try {
         result = await profileManager.delegateEdvCapabilities({
@@ -731,18 +716,8 @@ describe('Profile Manager API', () => {
       error.message.should.contain('edvId');
     });
     it('should fail if no hmac', async () => {
-      const edvId = 'z19uMCiPNET4YbcPpBcab5mEE';
-      const keyAgreementKey = {
-        id: 'z19xp4DANMn8k9Yy8m6ZCE6PV',
-        type: 'X25519KeyAgreementKey2019',
-      };
-      const parentCapabilities = {
-        edvId: 'z19uMCiPNET4YbcPpBcab5mEE',
-        keyAgreementKey: {
-          id: 'z19xp4DANMn8k9Yy8m6ZCE6PV',
-          type: 'X25519KeyAgreementKey2019',
-        }
-      };
+      const {parentCapabilities, edvId, keyAgreementKey} = mockData;
+      delete parentCapabilities.hmac;
       let error, result = null;
       try {
         result = await profileManager.delegateEdvCapabilities({
@@ -757,18 +732,8 @@ describe('Profile Manager API', () => {
       error.message.should.contain('hmac');
     });
     it('should fail if no keyAgreementKey', async () => {
-      const edvId = 'z19uMCiPNET4YbcPpBcab5mEE';
-      const hmac = {
-        id: 'z19pHg1APVprWk1ALrcZUnXWL',
-        type: 'Sha256HmacKey2019'
-      };
-      const parentCapabilities = {
-        edvId: 'z19uMCiPNET4YbcPpBcab5mEE',
-        hmac: {
-          id: 'z19pHg1APVprWk1ALrcZUnXWL',
-          type: 'Sha256HmacKey2019'
-        },
-      };
+      const {parentCapabilities, edvId, hmac} = mockData;
+      delete parentCapabilities.keyAgreementKey;
       let error, result = null;
       try {
         result = await profileManager.delegateEdvCapabilities({

--- a/test/web/10-api.js
+++ b/test/web/10-api.js
@@ -1,7 +1,6 @@
 /*!
  * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
  */
-'use strict';
 
 import {ProfileManager} from 'bedrock-web-profile-manager';
 import {mockData} from './mock.data.js';
@@ -699,8 +698,32 @@ describe('Profile Manager API', () => {
       error.name.should.equal('TypeError');
       error.message.should.contain('profileId');
     });
+    it('should fail after parentCapabilities assertation', async () => {
+      const {
+        parentCapabilities,
+        edvId,
+        hmac,
+        keyAgreementKey
+      } = mockData;
+      let error, result = null;
+      try {
+        result = await profileManager.delegateEdvCapabilities({
+          parentCapabilities, edvId, hmac, keyAgreementKey
+        });
+      } catch(e) {
+        error = e;
+      }
+      should.not.exist(result);
+      should.exist(error);
+      error.name.should.equal('TypeError');
+      error.message.should.contain('Cannot read property \'id\' of undefined');
+    });
     it('should fail if no edvId', async () => {
-      const {parentCapabilities, hmac, keyAgreementKey} = mockData;
+      const {
+        parentCapabilities,
+        hmac,
+        keyAgreementKey
+      } = mockData;
       delete parentCapabilities.edv;
       let error, result = null;
       try {
@@ -716,7 +739,11 @@ describe('Profile Manager API', () => {
       error.message.should.contain('edvId');
     });
     it('should fail if no hmac', async () => {
-      const {parentCapabilities, edvId, keyAgreementKey} = mockData;
+      const {
+        parentCapabilities,
+        edvId,
+        keyAgreementKey
+      } = mockData;
       delete parentCapabilities.hmac;
       let error, result = null;
       try {
@@ -732,7 +759,11 @@ describe('Profile Manager API', () => {
       error.message.should.contain('hmac');
     });
     it('should fail if no keyAgreementKey', async () => {
-      const {parentCapabilities, edvId, hmac} = mockData;
+      const {
+        parentCapabilities,
+        edvId,
+        hmac
+      } = mockData;
       delete parentCapabilities.keyAgreementKey;
       let error, result = null;
       try {

--- a/test/web/10-api.js
+++ b/test/web/10-api.js
@@ -68,7 +68,8 @@ describe('Profile Manager API', () => {
       });
     });
     it('should succeed if profile exists', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         const content = {didMethod: 'v1', didOptions: {mode: 'test'}};
         const {id: profileId} = await profileManager.createProfile(content);
@@ -84,7 +85,8 @@ describe('Profile Manager API', () => {
       result.invocationSigner.should.have.property('sign');
     });
     it('should fail if profileId is undefined', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.getProfileSigner({profileId: undefined});
       } catch(e) {
@@ -96,7 +98,8 @@ describe('Profile Manager API', () => {
       error.message.should.contain('profileId');
     });
     it('should fail if profileId is an empty string', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.getProfileSigner({profileId: ''});
       } catch(e) {
@@ -130,7 +133,8 @@ describe('Profile Manager API', () => {
       });
     });
     it('should succeed if profile exists', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         const content = {didMethod: 'v1', didOptions: {mode: 'test'}};
         const {id: profileId} = await profileManager.createProfile(content);
@@ -145,7 +149,8 @@ describe('Profile Manager API', () => {
       result.should.have.property('zcaps');
     });
     it('should fail if profileId is undefined', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.getAgent({profileId: undefined});
       } catch(e) {
@@ -157,7 +162,8 @@ describe('Profile Manager API', () => {
       error.message.should.contain('profileId');
     });
     it('should fail if profileId is an empty string', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.getAgent({profileId: ''});
       } catch(e) {
@@ -191,7 +197,8 @@ describe('Profile Manager API', () => {
       });
     });
     it('should successfully initialize w/ default signer', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         const content = {didMethod: 'v1', didOptions: {mode: 'test'}};
         const {id: profileId} = await profileManager.createProfile(content);
@@ -226,7 +233,8 @@ describe('Profile Manager API', () => {
       result.profileAgent.should.have.property('zcaps');
     });
     it('should successfully initialize w/ ephemeral signer', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         const content = {didMethod: 'v1', didOptions: {mode: 'test'}};
         const {id: profileId} = await profileManager.createProfile(content);
@@ -261,7 +269,8 @@ describe('Profile Manager API', () => {
       result.profileAgent.should.have.property('zcaps');
     });
     it('should successfully initialize w/o ephemeral signer', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         const content = {didMethod: 'v1', didOptions: {mode: 'test'}};
         const {id: profileId} = await profileManager.createProfile(content);
@@ -297,7 +306,8 @@ describe('Profile Manager API', () => {
       result.profileAgent.should.have.property('zcaps');
     });
     it('should fail if profileId is undefined', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.initializeAccessManagement({
           profileId: undefined,
@@ -314,7 +324,8 @@ describe('Profile Manager API', () => {
       error.message.should.contain('profileId');
     });
     it('should fail if profileId is an empty string', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.initializeAccessManagement({
           profileId: '',
@@ -353,7 +364,8 @@ describe('Profile Manager API', () => {
       });
     });
     it('should succeed w/ initialized profile', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         const content = {didMethod: 'v1', didOptions: {mode: 'test'}};
         const {id: profileId} = await profileManager.createProfile(content);
@@ -376,7 +388,8 @@ describe('Profile Manager API', () => {
       should.exist(result);
     });
     it(`should fail w/ uninitialized profile access management`, async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         const content = {didMethod: 'v1', didOptions: {mode: 'test'}};
         const {id} = await profileManager.createProfile(content);
@@ -388,7 +401,8 @@ describe('Profile Manager API', () => {
       should.exist(error);
     });
     it(`should fail w/ unintialized profile access management`, async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         const content = {didMethod: 'v1', didOptions: {mode: 'test'}};
         const {id} = await profileManager.createProfile(content);
@@ -400,7 +414,8 @@ describe('Profile Manager API', () => {
       should.exist(error);
     });
     it('should fail if profileId is undefined', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.getProfile({id: undefined});
       } catch(e) {
@@ -412,7 +427,8 @@ describe('Profile Manager API', () => {
       error.message.should.contain('id');
     });
     it('should fail if profileId is an empty string', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.getProfile({id: ''});
       } catch(e) {
@@ -446,7 +462,8 @@ describe('Profile Manager API', () => {
       });
     });
     it('should succeed if profile exists', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         const content = {didMethod: 'v1', didOptions: {mode: 'test'}};
         const {id: profileId} = await profileManager.createProfile(content);
@@ -464,7 +481,8 @@ describe('Profile Manager API', () => {
       result.should.have.property('kmsClient');
     });
     it('should fail if profileId is undefined', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.getProfileKeystoreAgent(
           {profileId: undefined});
@@ -477,7 +495,8 @@ describe('Profile Manager API', () => {
       error.message.should.contain('profileId');
     });
     it('should fail if profileId is an empty string', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.getProfileKeystoreAgent({profileId: ''});
       } catch(e) {
@@ -511,7 +530,8 @@ describe('Profile Manager API', () => {
       });
     });
     it('should succeed w/ initialized profile access management', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         const content = {didMethod: 'v1', didOptions: {mode: 'test'}};
         const {id: profileId} = await profileManager.createProfile(content);
@@ -541,7 +561,8 @@ describe('Profile Manager API', () => {
       should.exist(result);
     });
     it('should fail w/ uninitialized profile access management', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         const content = {didMethod: 'v1', didOptions: {mode: 'test'}};
         const {id: profileId} = await profileManager.createProfile(content);
@@ -554,7 +575,8 @@ describe('Profile Manager API', () => {
       should.exist(error);
     });
     it('should fail if profileId is undefined', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.getAccessManager({profileId: undefined});
       } catch(e) {
@@ -566,7 +588,8 @@ describe('Profile Manager API', () => {
       error.message.should.contain('profileId');
     });
     it('should fail if profileId is an empty string', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.getAccessManager({profileId: ''});
       } catch(e) {
@@ -600,7 +623,8 @@ describe('Profile Manager API', () => {
       });
     });
     it('should succeed if profile exists', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         const content = {didMethod: 'v1', didOptions: {mode: 'test'}};
         const {id: profileId} = await profileManager.createProfile(content);
@@ -618,7 +642,8 @@ describe('Profile Manager API', () => {
       result.edvClient.should.have.property('hmac');
     });
     it('should fail if profileId is undefined', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.createProfileEdv({
           profileId: undefined,
@@ -633,7 +658,8 @@ describe('Profile Manager API', () => {
       error.message.should.contain('profileId');
     });
     it('should fail if profileId is an empty string', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.createProfileEdv({
           profileId: '',
@@ -659,7 +685,8 @@ describe('Profile Manager API', () => {
       });
     });
     it('should fail if profileId is undefined', async () => {
-      let error, result;
+      let error;
+      let result;
       const delegateRequest = {
         referenceId: 'test.org:test-edv',
         allowedAction: ['read', 'write'],
@@ -679,7 +706,8 @@ describe('Profile Manager API', () => {
       error.message.should.contain('profileId');
     });
     it('should fail if profileId is an empty string', async () => {
-      let error, result;
+      let error;
+      let result;
       const delegateRequest = {
         referenceId: 'test.org:test-edv',
         allowedAction: ['read', 'write'],
@@ -705,7 +733,8 @@ describe('Profile Manager API', () => {
         hmac,
         keyAgreementKey
       } = mockData;
-      let error, result = null;
+      let error = null;
+      let result = null;
       try {
         result = await profileManager.delegateEdvCapabilities({
           parentCapabilities, edvId, hmac, keyAgreementKey
@@ -725,7 +754,8 @@ describe('Profile Manager API', () => {
         keyAgreementKey
       } = mockData;
       delete parentCapabilities.edv;
-      let error, result = null;
+      let error = null;
+      let result = null;
       try {
         result = await profileManager.delegateEdvCapabilities({
           parentCapabilities, hmac, keyAgreementKey
@@ -745,7 +775,8 @@ describe('Profile Manager API', () => {
         keyAgreementKey
       } = mockData;
       delete parentCapabilities.hmac;
-      let error, result = null;
+      let error = null;
+      let result = null;
       try {
         result = await profileManager.delegateEdvCapabilities({
           parentCapabilities, edvId, keyAgreementKey
@@ -765,7 +796,8 @@ describe('Profile Manager API', () => {
         hmac
       } = mockData;
       delete parentCapabilities.keyAgreementKey;
-      let error, result = null;
+      let error;
+      let result;
       try {
         result = await profileManager.delegateEdvCapabilities({
           parentCapabilities, edvId, hmac
@@ -791,7 +823,8 @@ describe('Profile Manager API', () => {
       });
     });
     it('should fail if profileId is undefined', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.getCollection({
           profileId: undefined,
@@ -807,7 +840,8 @@ describe('Profile Manager API', () => {
       error.message.should.contain('profileId');
     });
     it('should fail if profileId is an empty string', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.getCollection({
           profileId: '',
@@ -834,7 +868,8 @@ describe('Profile Manager API', () => {
       });
     });
     it('should fail if profileId is undefined', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.getProfileEdvAccess({
           profileId: undefined,
@@ -849,7 +884,8 @@ describe('Profile Manager API', () => {
       error.message.should.contain('profileId');
     });
     it('should fail if profileId is an empty string', async () => {
-      let error, result;
+      let error;
+      let result;
       try {
         result = await profileManager.getProfileEdvAccess({
           profileId: '',

--- a/test/web/mock.data.js
+++ b/test/web/mock.data.js
@@ -1,0 +1,26 @@
+/*!
+ * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
+ */
+
+export const mockData = {
+  edvId: 'z19uMCiPNET4YbcPpBcab5mEE',
+  hmac: {
+    id: 'z19pHg1APVprWk1ALrcZUnXWL',
+    type: 'Sha256HmacKey2019'
+  },
+  keyAgreementKey: {
+    id: 'z19xp4DANMn8k9Yy8m6ZCE6PV',
+    type: 'X25519KeyAgreementKey2019',
+  },
+  parentCapabilities: {
+    edv: 'z19uMCiPNET4YbcPpBcab5mEE',
+    hmac: {
+      id: 'z19pHg1APVprWk1ALrcZUnXWL',
+      type: 'Sha256HmacKey2019'
+    },
+    keyAgreementKey: {
+      id: 'z19xp4DANMn8k9Yy8m6ZCE6PV',
+      type: 'X25519KeyAgreementKey2019',
+    }
+  }
+};


### PR DESCRIPTION
Closes #55 

I am concerned that `hmac` and `keyAgreementKey` would never be included in `parentCapabilities`, because `delegateEdvCapabilities` is only called once, and the [only properties included](https://github.com/digitalbazaar/bedrock-web-profile-manager/blob/master/ProfileManager.js#L324) in `parentCapabilities` are `edv` and `edvRevocation`.
