### PR TITLE
Remove assert-plus in keyResolver

### DIFF
--- a/keyResolver.js
+++ b/keyResolver.js
@@ -1,18 +1,19 @@
 /*!
  * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
  */
-import {httpClient} from '@digitalbazaar/http-client';
-import assert from 'assert-plus';
 import didIo from 'did-io';
 import {driver as keyDriver} from 'did-method-key';
 import {driver as veresDriver} from 'did-veres-one';
+import {httpClient} from '@digitalbazaar/http-client';
 
 // config did-io to support did:key and did:v1 drivers
 didIo.use('key', keyDriver());
 didIo.use('v1', veresDriver());
 
 async function keyResolver({id} = {}) {
-  assert.string(id, 'id');
+  if(typeof id !== 'string') {
+    throw new TypeError('"id" string is required.');
+  }
   if(id.startsWith('did:')) {
     return didIo.get({did: id, forceConstruct: true});
   }


### PR DESCRIPTION
When testing wallet with the latest version of `bedrock-web-profile-manager`, I got this error [Vue warn]: Failed to resolve async component: () => Promise.all(/*! import() | BrRoot Reason: ReferenceError: Buffer is not defined.

turns out assert-plus is a node module and cannot be used in web, so I removed it. This fixes the error. 

