### PR TITLE
Use `allSettled` to ensure only provisioned profiles are returned.

### DIFF
--- a/ProfileManager.js
+++ b/ProfileManager.js
@@ -526,18 +526,20 @@ export default class ProfileManager {
 
     // TODO: Use proper promise-fun library to limit concurrency
     const profiles = await Promise.allSettled(promises);
-    if(!type) {
-      return profiles;
-    }
     // Only return valid profiles
     // if there is a malformed profile warn the client
-    return profiles.filter(profile => {
-      if(!profile.status) {
+    return profiles.reduce((result, {status,value:profile}) => {
+      if(status === 'rejected'){
         console.warn('Filtering out unprovisioned profile.');
-        return false;
+        return result
+      } 
+      if(!type){
+        return result.concat(profile)
       }
-      return profile.type.includes(type);
-    });
+      if(profile.type.includes(type)){
+        return result.concat(profile)
+      } 
+    },[]);
   }
 
   async getProfileKeystoreAgent({profileId} = {}) {

--- a/ProfileManager.js
+++ b/ProfileManager.js
@@ -525,11 +525,19 @@ export default class ProfileManager {
       this.getProfile({id: profileAgent.profile}));
 
     // TODO: Use proper promise-fun library to limit concurrency
-    const profiles = await Promise.all(promises);
+    const profiles = await Promise.allSettled(promises);
     if(!type) {
       return profiles;
     }
-    return profiles.filter(profile => profile.type.includes(type));
+    // Only return valid profiles
+    // if there is a malformed profile warn the client
+    return profiles.filter(profile => {
+      if(!profile.status) {
+        console.warn('Filtering out unprovisioned profile.');
+        return false;
+      }
+      return profile.type.includes(type);
+    });
   }
 
   async getProfileKeystoreAgent({profileId} = {}) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@digitalbazaar/ed25519-signature-2020": "^3.0.0",
     "@digitalbazaar/http-client": "^1.1.0",
     "@digitalbazaar/security-document-loader": "^1.0.0",
-    "@digitalbazaar/webkms-client": "^6.0.0",
+    "@digitalbazaar/webkms-client": "^6.0.1",
     "@digitalbazaar/zcapld": "^5.1.2",
     "bedrock-web-profile": "^3.0.0",
     "did-veres-one": "14.0.0-beta.1",


### PR DESCRIPTION
https://github.com/digitalbazaar/bedrock-web-profile-manager/issues/85