### PR TITLE
Fix destructuring of keystore id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 10.0.0 - 2021-09-03
 
+### Fixed
+- Fix destructuring of `keystoreId` in `delegateCapability()`. Previously
+  `keystoreAgent` had `keystore` property which provided the id, but now
+  it no longer has the `keystore` property, instead it has the `keystoreId`
+  property.
+- Update `bedrock-profile-http` in test.
+
+## 10.0.0 - 2021-09-03
+
 ### Changed
 - **BREAKING**: No changes to the public API. Must use bedrock-kms-http@9,
   bedrock-meter-http@2, bedrock-meter-usage-reporter@4, bedrock-profile@12,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # bedrock-web-profile-manager ChangeLog
 
-## 10.0.0 - 2021-09-03
+## 10.0.1 - 2021-TBD
 
 ### Fixed
 - Fix destructuring of `keystoreId` in `delegateCapability()`. Previously

--- a/ProfileManager.js
+++ b/ProfileManager.js
@@ -724,7 +724,7 @@ export default class ProfileManager {
     assert.nonEmptyString(profileId, 'profileId');
     const {invocationSigner: signer} = await this.getProfileSigner({profileId});
     const keystoreAgent = await this.getProfileKeystoreAgent({profileId});
-    const {id: keystoreId} = keystoreAgent.keystore;
+    const {keystoreId} = keystoreAgent;
     return utils.delegateCapability({signer, keystoreId, request});
   }
 

--- a/test/package.json
+++ b/test/package.json
@@ -29,7 +29,7 @@
     "bedrock-passport": "^6.1.0",
     "bedrock-permission": "^3.2.0",
     "bedrock-profile": "^12.0.0",
-    "bedrock-profile-http": "digitalbazaar/bedrock-profile-http#update-meter-creation",
+    "bedrock-profile-http": "^9.0.0",
     "bedrock-security-context": "^4.1.0",
     "bedrock-server": "^3.0.0",
     "bedrock-ssm-mongodb": "^6.0.0",


### PR DESCRIPTION
Also updated `bedrock-profile-http` dep  in test, it was using a branch which was merged and deleted.